### PR TITLE
Crappily support kind/len=N declarations.

### DIFF
--- a/lib/frepl/classifier.rb
+++ b/lib/frepl/classifier.rb
@@ -2,13 +2,13 @@ module Frepl
   class Classifier
     VARIABLE_NAME_REGEX = /[a-zA-Z][a-zA-Z0-9_]{,30}/
     ASSIGNABLE_VALUE_REGEX = /[^\s]+/
+    TYPE_REGEX = /real|integer|character/
     # TODO: parameter/dimension order shouldn't matter here
-    DECLARATION_REGEX = /\As*(real|integer|type)(\s*,?\s*parameter\s*,\s*)?(\s*,?\s*dimension\([^\)]+\))?\s*(?:::)?\s*(.*)/
+    DECLARATION_REGEX = /\As*(#{TYPE_REGEX})\s*(\((?:kind|len)=\d+\)){,1}+(\s*,?\s*parameter\s*,\s*)?(\s*,?\s*dimension\([^\)]+\))?\s*(?:::)?\s*([^(?:::)]*)/
     ASSIGNMENT_REGEX = /\As*(#{VARIABLE_NAME_REGEX})\s*=\s*(#{ASSIGNABLE_VALUE_REGEX})/
     OLDSKOOL_ARRAY_VALUE_REGEX = /\/[^\]]+\//
     F2003_ARRAY_VALUE_REGEX = /\[[^\]]+\]/
     ARRAY_VALUE_REGEX = /#{OLDSKOOL_ARRAY_VALUE_REGEX}|#{F2003_ARRAY_VALUE_REGEX}/
-    TYPE_REGEX = /real|integer|character/
     FUNCTION_REGEX = /(#{TYPE_REGEX})\s+function\s+(#{VARIABLE_NAME_REGEX})/
     SUBROUTINE_REGEX = /subroutine\s+(#{VARIABLE_NAME_REGEX})/
 
@@ -60,7 +60,7 @@ module Frepl
     def multi_declaration?
       m = current_line.match(DECLARATION_REGEX)
       return false unless m
-      if m[4].gsub(ARRAY_VALUE_REGEX, '').count(',') > 0
+      if m[5].gsub(ARRAY_VALUE_REGEX, '').count(',') > 0
         true
       else
         false
@@ -71,7 +71,7 @@ module Frepl
     def declaration?
       m = current_line.match(DECLARATION_REGEX)
       return false unless m
-      if m[4].gsub(ARRAY_VALUE_REGEX, '').count(',') == 0
+      if m[5].gsub(ARRAY_VALUE_REGEX, '').count(',') == 0
         true
       else
         false

--- a/lib/frepl/statements/declaration.rb
+++ b/lib/frepl/statements/declaration.rb
@@ -1,6 +1,6 @@
 module Frepl
   class Declaration < SinglelineStatement
-    attr_reader :variable_name, :assigned_value, :type
+    attr_reader :variable_name, :assigned_value, :type, :len, :kind
 
     def accept(visitor)
       visitor.visit_declaration(self)
@@ -18,9 +18,17 @@ module Frepl
     
     def parse
       match_data = line.match(Frepl::Classifier::DECLARATION_REGEX)
-      variable_part = match_data[4]
+      variable_part = match_data[5]
       variable_data = variable_part.match(/\s*([^\s=])\s*+=*\s*(.*)?/)
       @variable_name = variable_data[1]
+      kind_len = match_data[2]
+      if kind_len
+        if kind_len.match(/len/)
+          @len = kind_len.match(/=(\d+)/)[1]
+        else
+          @kind = kind_len.match(/=(\d+)/)[1]
+        end
+      end
       @assigned_value = variable_data[2].empty? ? nil : variable_data[2]
       @type = match_data[1]
     end

--- a/spec/lib/frepl/classifier_spec.rb
+++ b/spec/lib/frepl/classifier_spec.rb
@@ -19,6 +19,30 @@ RSpec.describe Frepl::Classifier do
       end
     end
 
+    context 'single real kind declaration with assignment' do
+      let(:line) { 'real(kind=4) :: a = 1.0' }
+
+      it 'returns a single declaration' do
+        expect(classifier.classify(line)).to be_a(Frepl::Declaration)
+      end
+    end
+
+    context 'single character declaration' do
+      let(:line) { 'character(len=4) name' }
+
+      it 'returns a single declaration' do
+        expect(classifier.classify(line)).to be_a(Frepl::Declaration)
+      end
+    end
+
+    context 'single character declaration with assignment' do
+      let(:line) { 'character(len=4) :: name = "john"' }
+
+      it 'returns a single declaration' do
+        expect(classifier.classify(line)).to be_a(Frepl::Declaration)
+      end
+    end
+
     context 'single Fortran 2003 array declaration' do
       let(:line) { 'integer, dimension(3) :: a = [1,2,3]' }
 

--- a/spec/lib/frepl/declaration_spec.rb
+++ b/spec/lib/frepl/declaration_spec.rb
@@ -57,6 +57,22 @@ RSpec.describe Frepl::Declaration do
     end
   end
 
+  context 'real with kind' do
+    let(:d) { Frepl::Declaration.new('real(kind=4) :: a = 2.3') }
+
+    it 'extracts variable name' do
+      expect(d.variable_name).to eq('a')
+    end
+
+    it 'has assigned value [1,2,3]' do
+      expect(d.assigned_value).to eq('2.3')
+    end
+
+    it 'has kind' do
+      expect(d.kind).to eq('4')
+    end
+  end
+
   describe '#==' do
     let(:d) { Frepl::Declaration.new('integer a') }
 

--- a/spec/lib/frepl_spec.rb
+++ b/spec/lib/frepl_spec.rb
@@ -85,6 +85,20 @@ RSpec.describe Frepl do
       end
     end
 
+    context 'changing the kind of a real' do
+      it 'works' do
+        expect(Frepl).to receive(:output).with(match(/12\.\d{7}\s+/))
+        expect(Frepl).to receive(:output).with(match(/12\.\d{15}\s+/))
+        file = [
+          'real(kind=4) :: a = 3.14',
+          'write(*,*) a * 4',
+          'real(kind=8) :: a = 3.14',
+          'write(*,*) a * 4'
+        ]
+        frepl.run_file(file)
+      end
+    end
+
     context 'redefining a subroutine' do
       it 'works' do
         # TODO shouldn't require this first expectation -- don't do IO


### PR DESCRIPTION
Odd matching in functional spec seems necessary to accommodate possibly different output from different compilers, this could be wrong though.
