### PR TITLE
Add Travis-CI integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: ruby
+rvm:
+  - 2.1
+env:
+  - FORTRAN_COMPILER=/usr/bin/gfortran-4.9
+script: bundle exec rspec
+
+cache:
+  apt: true
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gfortran-4.9

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Frepl
 
+[![Build Status](https://travis-ci.org/lukeasrodgers/frepl.svg?branch=add-travis)](https://travis-ci.org/lukeasrodgers/frepl)
+
 Frepl (Fortran REPL) is an experimental ruby-based REPL for Fortran,
 that I wrote because I was trying to learn Fortran, and I find the feedback
 loop you get with a REPL makes learning a language much easier and more

--- a/lib/frepl.rb
+++ b/lib/frepl.rb
@@ -25,7 +25,7 @@ module Frepl
     end
 
     def initialize
-      Frepl.compiler = 'gfortran'
+      Frepl.compiler = ENV['FORTRAN_COMPILER'] || 'gfortran'
       Frepl.debug = false
       reset!
     end


### PR DESCRIPTION
- Need to specify apt-cache to get gfortran to be installed (see https://github.com/travis-ci/travis-ci/issues/3957).
- Tried symlinking gfortran to /usr/bin/gfortran-4.9 but that didn't work for some reason.

Closes #2
